### PR TITLE
Shutdown on Ctrl+C and SIGTERM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,6 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
- "scopeguard",
  "serde",
  "structopt",
  "tokio",
@@ -704,12 +703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +742,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -871,6 +873,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ publish = true
 maintenance = { status = "experimental" }
 
 [dependencies]
-tokio = { version = "1.34", features = ["rt", "net", "macros", "io-util", "sync", "time"] }
+tokio = { version = "1.34", features = ["rt", "net", "macros", "io-util", "sync", "time", "signal"] }
 structopt = "0.3"
 log = "0.4"
 env_logger = "0.10"


### PR DESCRIPTION
Before this change, the program would only exit once all spawned tasks had completed. With the new behavior, the program also quits if either `Ctrl-C` or `SIGTERM` is received. The advantage is that operations such as `docker compose restart` now complete almost immediately. Previously, a graceful shutdown request sent by Docker via `SIGTERM` had no effect, causing a 10-second wait before Docker forcefully killed the previous instance.

This solution is not perfect, since all spawned tasks are effectively terminated when the main function returns. However, it is not a step back from the previous behavior — termination now simply happens sooner.

I tested both shutdown methods and have deployed this change locally. On that note, thanks for creating this project!